### PR TITLE
[RD-31117] Add `countOnly` attribute to `/elements` sub-element endpoint

### DIFF
--- a/WebDriverAgentLib/Categories/XCUIElement+FBFind.h
+++ b/WebDriverAgentLib/Categories/XCUIElement+FBFind.h
@@ -26,6 +26,14 @@ NS_ASSUME_NONNULL_BEGIN
 - (NSArray<XCUIElement *> *)fb_descendantsMatchingClassName:(NSString *)className shouldReturnAfterFirstMatch:(BOOL)shouldReturnAfterFirstMatch;
 
 /**
+ Returns the count of descendants matching given class name
+ 
+ @param className requested class name
+ @return the number of descendants matching given class name
+ */
+- (NSInteger)fb_descendantsCountMatchingClassName:(NSString *)className;
+
+/**
  Returns an array of descendants matching given accessibility id
 
  @param accessibilityId requested accessibility id

--- a/WebDriverAgentLib/Categories/XCUIElement+FBFind.m
+++ b/WebDriverAgentLib/Categories/XCUIElement+FBFind.m
@@ -52,6 +52,12 @@
   return result.copy;
 }
 
+- (NSInteger) fb_descendantsCountMatchingClassName:(NSString *)className
+{
+  XCUIElementType type = [FBElementTypeTransformer elementTypeWithTypeName:className];
+  XCUIElementQuery *query = [self descendantsMatchingType:type];
+  return query.count;
+}
 
 #pragma mark - Search by property value
 

--- a/WebDriverAgentTests/IntegrationTests/XCUIElementFBFindTests.m
+++ b/WebDriverAgentTests/IntegrationTests/XCUIElementFBFindTests.m
@@ -56,6 +56,12 @@
   XCTAssertEqualObjects(types.lastObject, @(XCUIElementTypeButton), @"matchingSnapshots should contain only one type");
 }
 
+- (void)testDescendantsCountWithClassName
+{
+  NSInteger count = [self.testedView fb_descendantsCountMatchingClassName:@"XCUIElementTypeButton"];
+  XCTAssertEqual(count, 4);
+}
+
 - (void)testSingleDescendantWithClassName
 {
   NSArray<XCUIElement *> *matchingSnapshots = [self.testedView fb_descendantsMatchingClassName:@"XCUIElementTypeButton" shouldReturnAfterFirstMatch:YES];


### PR DESCRIPTION
* If `countOnly` is set in the request body, then short-circuit finding
sub-elements and instead do a simple sub-element count query.
* Only support count elements by class name, since that's all we need
for modal dialog checks.